### PR TITLE
Make #post_url input read-only instead of disabled

### DIFF
--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -16,6 +16,6 @@
       <% end %>
     </div>
   </div>
-  <input id="post_url" class="input-xlarge" type="text"
-    value="<%= p_url(@post) %>" disabled="disabled"></input>
+  <input id="post_url" class="input-xlarge uneditable-input" type="text"
+    value="<%= p_url(@post) %>"></input>
 </div>


### PR DESCRIPTION
This makes it easier for copying the url since now the user can select the text inside of the input field
