### PR TITLE
Make the post title a link to the post

### DIFF
--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -1,5 +1,5 @@
 <% if post.title.present? %>
-  <h3><%= post.title %></h3>
+  <h3><%= link_to post.title, post %></h3>
 <% else %>
   <span>&nbsp;</span>
 <% end %>


### PR DESCRIPTION
Nothing on the index page points to the post itself except that little button.. that's a little annoying!
