### PR TITLE
Remove default commenter from migration

### DIFF
--- a/db/migrate/20121109202549_create_comments.rb
+++ b/db/migrate/20121109202549_create_comments.rb
@@ -1,7 +1,7 @@
 class CreateComments < ActiveRecord::Migration
   def change
     create_table :comments do |t|
-      t.string :commenter, :default => "Anonymus"
+      t.string :commenter
       t.text :body
       t.references :post
 


### PR DESCRIPTION
This was missing from commit 3297c389a.
