### PR TITLE
to make new/help visible use white icons

### DIFF
--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -8,14 +8,14 @@
         <ul class="nav pull-right">
           <li>
             <%= link_to new_post_path do %>
-              <i class="icon-plus"></i>
+              <i class="icon-plus-sign icon-white"></i>
             <% end %>
           </li>
         </ul>
         <ul class="nav pull-right">
           <li>
             <%= link_to help_path do %>
-              <i class="icon-question-sign"></i>
+              <i class="icon-question-sign icon-white"></i>
             <% end %>
           </li>
         </ul>


### PR DESCRIPTION
To make the new/help signs more visible use the white icons
of bootstrap.wq
