### PR TITLE
remove github-linguist

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,9 +10,6 @@ gem 'sqlite3'
 # Syntax highlighter
 gem "pygments.rb",  git: "https://github.com/tmm1/pygments.rb", branch: "master"
 
-# Language detection
-gem "github-linguist", "~> 2.3.4" , require: "linguist"
-
 # Gems used only for assets and not required
 # in production environments by default.
 group :assets do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,7 +40,6 @@ GEM
     arel (3.0.2)
     bootstrap-sass (2.0.4.2)
     builder (3.0.4)
-    charlock_holmes (0.6.9)
     coffee-rails (3.2.2)
       coffee-script (>= 2.2.0)
       railties (~> 3.2.0)
@@ -50,14 +49,8 @@ GEM
     coffee-script-source (1.4.0)
     diffy (2.1.3)
     erubis (2.7.0)
-    escape_utils (0.2.4)
     execjs (1.4.0)
       multi_json (~> 1.0)
-    github-linguist (2.3.4)
-      charlock_holmes (~> 0.6.6)
-      escape_utils (~> 0.2.3)
-      mime-types (~> 1.19)
-      pygments.rb (>= 0.2.13)
     hike (1.2.1)
     i18n (0.6.1)
     journey (1.0.4)
@@ -127,7 +120,6 @@ DEPENDENCIES
   bootstrap-sass (~> 2.0.0)
   coffee-rails (~> 3.2.1)
   diffy
-  github-linguist (~> 2.3.4)
   jquery-rails
   pygments.rb!
   rails (= 3.2.11)

--- a/config/initializers/1_pygments.rb
+++ b/config/initializers/1_pygments.rb
@@ -1,3 +1,1 @@
 require 'pygments'
-
-include Linguist::BlobHelper


### PR DESCRIPTION
Since we won't detect the language/content-type automatically
the dependency to github-linguist is unnecessary.
