### PR TITLE
add upload file and content detection

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,9 @@ gem 'rails', '3.2.11'
 
 gem 'sqlite3'
 
+# Language detection
+gem "github-linguist", "~> 2.3.4" , require: "linguist"
+
 # Syntax highlighter
 gem "pygments.rb",  git: "https://github.com/tmm1/pygments.rb", branch: "master"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,6 +41,7 @@ GEM
     bcrypt-ruby (3.0.1)
     bootstrap-sass (2.0.4.2)
     builder (3.0.4)
+    charlock_holmes (0.6.9)
     coffee-rails (3.2.2)
       coffee-script (>= 2.2.0)
       railties (~> 3.2.0)
@@ -55,8 +56,14 @@ GEM
       warden (~> 1.2.1)
     diffy (2.1.3)
     erubis (2.7.0)
+    escape_utils (0.2.4)
     execjs (1.4.0)
       multi_json (~> 1.0)
+    github-linguist (2.3.4)
+      charlock_holmes (~> 0.6.6)
+      escape_utils (~> 0.2.3)
+      mime-types (~> 1.19)
+      pygments.rb (>= 0.2.13)
     hike (1.2.1)
     i18n (0.6.1)
     journey (1.0.4)
@@ -130,6 +137,7 @@ DEPENDENCIES
   coffee-rails (~> 3.2.1)
   devise
   diffy
+  github-linguist (~> 2.3.4)
   jquery-rails
   pygments.rb!
   rails (= 3.2.11)

--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -1,2 +1,18 @@
 module PostsHelper
+  require 'tempfile'
+
+  def get_content_type(data)
+    content_type = 'None'
+    Tempfile.open(['uploaded', data.original_filename.downcase],
+      Rails.root.join('tmp')) do |f|
+      # set executable bits so Linguist will check for shebangs
+      f.chmod(0755)
+      f.print(content)
+      f.flush
+      unless Linguist::FileBlob.new(f.path).language.nil?
+        content_type = Linguist::FileBlob.new(f.path).language.name
+      end
+    end
+    return content_type
+  end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,9 +1,13 @@
 class Post < ActiveRecord::Base
 
+  def self.MaxUploadSize
+    102400 # 100kb
+  end
+
   validates_presence_of :content
   validates_presence_of :content_type
   # not more content then 1MB
-  validates_length_of :content, :maximum => 104875
+  validates_length_of :content, :maximum => Post.MaxUploadSize
   validates_length_of :title, :maximum => 255
   validates_length_of :author, :maximum => 255
   attr_accessible :content, :title, :author, :content_type

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -22,13 +22,6 @@
     <div class="controls">
       <%= f.text_field :title, :id => "inputTitle", :class => "check4contenttype" %>
     </div>
-    <label class="control-label" for="inputContent">
-      <%= f.label :content %>
-    </label>
-    <div class="controls">
-      <%= f.text_area :content, {:class => "input-xxlarge", :rows => 15,
-        :id => "inputContent"} %>
-    </div>
     <label class="control-label" for="inputAuthor">
       <%= f.label :author %>
     </label>
@@ -36,12 +29,31 @@
       <%= f.text_field :author, :id => "inputAuthor",
         :placeholder => user_signed_in? ? current_user.email : "Anonymous" %>
     </div>
+
     <label class="control-label" for="inputContentType">
       <%= f.label :content_type %>
     </label>
     <div class="controls">
        <%= f.select(:content_type, Post.file_extensions.values.uniq,
          :id => "inputContentType")%>
+    </div>
+
+    <h3>Enter your Content here</h3>
+    <label class="control-label" for="inputContent">
+      <%= f.label :content %>
+    </label>
+    <div class="controls">
+      <%= f.text_area :content, {:class => "input-xxlarge", :rows => 15,
+        :id => "inputContent"} %>
+    </div>
+
+    <h3>And/Or Upload a File</h3>
+    <span class="label label-inverse">
+      Max-Size: <%= Post.MaxUploadSize / 1024 %> kb
+    </span>
+    <div class="controls">
+      <%= f.file_field :upload_file, { :id => "inputUploadFile",
+        :class => "input-xxlarge" } %>
     </div>
 
   </div>


### PR DESCRIPTION
Add the possibility to create a new post by uploading
a file and autodetect its content-type.

If the user uploads a file and enter s.th. in content
they get combined.

If the user leaves the title blank and uploads a file
the filename is used as title.
