### PR TITLE
limit lines in preview to 10

### DIFF
--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -1,2 +1,13 @@
 module PostsHelper
+
+  def preview_content(post)
+    options = { options: {encoding: 'utf-8'} }
+    if Pygments::Lexer.find(post.content_type)
+      options.merge!(lexer: post.content_type.downcase)
+    end
+    lines = post.content.split("\n")
+    lines[Post.MaxPreviewLines] = "..." if lines.size >= Post.MaxPreviewLines
+    Pygments.highlight(lines[0..Post.MaxPreviewLines].join("\n"), options)
+  end
+
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -29,6 +29,10 @@ class Post < ActiveRecord::Base
     }
   end
 
+  def self.MaxPreviewLines
+    10
+  end
+
   def self.feed(last)
     self.includes(:comments)
       .where("created_at < ? ", last).where(:newest => true)

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -4,14 +4,9 @@
 <% else %>
   <span>&nbsp;</span>
 <% end %>
-  <%=
-    options = { options: {encoding: 'utf-8'} }
-    if Pygments::Lexer.find(@post.content_type)
-      options.merge!(lexer: @post.content_type.downcase)
-    end
-    Pygments.highlight(
-      truncate(@post.content, :length => 800, :omission => "\n\n..."),
-      options).html_safe %>
+
+<%= preview_content(@post).html_safe %>
+
 <% if @post.author.present? %>
   <small class="author">- <%= @post.author %></small>
 <% else %>


### PR DESCRIPTION
Instead of limiting the chars we should limit the lines.
It's more readable and also makes highlighting for pygments
more reliable.
