### PR TITLE
fade out posts on deletion

### DIFF
--- a/app/assets/javascripts/posts.js
+++ b/app/assets/javascripts/posts.js
@@ -38,10 +38,7 @@ $(document).ready(function(){
       element.val(filenames['']);
     }
   });
-});
 
-$(document).ready(
-  function(){
   $("a#like_trigger").bind("ajax:success",
     function(evt, data, status, xhr){
       if (data.errors) {
@@ -53,6 +50,21 @@ $(document).ready(
           "<i class=\"icon-thumbs-down\"></i> " + data.dislikes);
         $("div#liker").html(data.liker);
         $("div#disliker").html(data.disliker);
+      }
+    });
+
+  $("a#delete_trigger").bind("ajax:success",
+    function(evt, data, status, xhr){
+      if (data.errors) {
+        $("p#alert").html(data.errors);
+      } else {
+        $('div#preview_area'+data.postid).fadeOut("slow");
+        $("p#notice").html(data.notice);
+        if (window.location.pathname != "/") {
+          setTimeout(function() {
+            window.location.href = "/";
+          }, 2000);
+        }
       }
     });
 });

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -105,8 +105,9 @@ class PostsController < ApplicationController
     @post.destroy
 
     respond_to do |format|
-      format.html { redirect_to posts_url }
-      format.json { head :no_content }
+      #format.html { redirect_to posts_url }
+      format.json { render :json => { :postid => @post.id,
+        :notice => "Snippet deleted" } }
     end
   end
 

--- a/app/views/posts/_options.html.erb
+++ b/app/views/posts/_options.html.erb
@@ -19,8 +19,9 @@
     <%= link_to posts_path, :class => "btn btn-small", :title => "Posts" do %>
       <i class="icon-align-justify"></i>
     <% end %>
-    <%= link_to @post, method: :delete,
-        data: { confirm: 'Are you sure?' }, :class => "btn btn-small" do %>
+    <%= link_to @post, method: :delete, :remote => true,
+        data: { confirm: 'Are you sure?' }, :class => "btn btn-small",
+        :id => "delete_trigger", :title => "Delete" do %>
       <i class="icon-trash"></i>
     <% end %>
     <%= link_to like_post_path(@post), :class => "btn btn-small like",

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -1,4 +1,5 @@
 <% @post = post %>
+<div id="preview_area<%= @post.id %>">
 <% if @post.title.present? %>
   <h3><%= link_to @post.title, @post %></h3>
 <% else %>
@@ -24,3 +25,4 @@
 
 <br />
 <br />
+</div>


### PR DESCRIPTION
Use funky FadeOut effect to remove a deletet snippet from
the view.

If the user is on the show-page he gets redirected after
2 seconds to the start page.
