### PR TITLE
Use thin as default webserver

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,8 @@ gem 'coffee-rails'
 gem 'bootstrap-sass'
 gem 'uglifier'
 
+gem 'thin'
+
 # Language detection
 gem "github-linguist", "~> 2.3.4" , require: "linguist"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,6 +48,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.6.2)
+    daemons (1.1.9)
     devise (3.0.0.rc)
       bcrypt-ruby (~> 3.0)
       orm_adapter (~> 0.1)
@@ -56,6 +57,7 @@ GEM
     diffy (2.1.4)
     erubis (2.7.0)
     escape_utils (0.2.4)
+    eventmachine (1.0.3)
     execjs (1.4.0)
       multi_json (~> 1.0)
     github-linguist (2.3.4)
@@ -109,6 +111,10 @@ GEM
       activesupport (>= 3.0)
       sprockets (~> 2.8)
     sqlite3 (1.3.7)
+    thin (1.6.1)
+      daemons (>= 1.0.9)
+      eventmachine (>= 1.0.0)
+      rack (>= 1.0.0)
     thor (0.18.1)
     thread_safe (0.1.0)
       atomic
@@ -139,4 +145,5 @@ DEPENDENCIES
   railties
   sass-rails
   sqlite3
+  thin
   uglifier


### PR DESCRIPTION
thin is the better choice when running rails as direct service.
