### PR TITLE
Use fixed and known to be working rvm version.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -27,6 +27,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
     chef.json = {
       :rvm => {
+        :version => "1.17.10",
         :rubies => ["ruby-1.9.3-head"],
         :default_ruby => "ruby-1.9.3-head",
       }


### PR DESCRIPTION
Addresses Issue https://github.com/kmerz/graveio/issues/45
as reported by dloss.
