### PR TITLE
Fix version of travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-  - 2.0.0
+  - 1.9.3
 
 before_install:
   - sudo apt-get update -qq


### PR DESCRIPTION
We don't have Ruby 2.0.0 on Vagrant and it
seems to be broken with Ruby 2.0.0 on Travis.

We should have both versions in sync so a successful build
in Vagrant also succeeds in Travis.
