### PR TITLE
Drop "sudo -E" when running "bundle install"

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Machine:
 ```
 vagrant ssh
 cd /vagrant
-sudo -E bundle install
+bundle install
 rake db:create && rake db:migrate
 rake test
 rails s


### PR DESCRIPTION
Get rid of erroneous "sudo -E" when running "bundle install" as mentioned in
README.md as discussed in https://github.com/kmerz/graveio/pull/50
