### PR TITLE
Always use the most verbose log level specified

### DIFF
--- a/public/bin/bury.rb
+++ b/public/bin/bury.rb
@@ -108,11 +108,11 @@ class Bury
         "Without this flag, the value in config will be used") do |port|
         attrs[:port] = port
       end
-      opts.on("-d", "--debug", "Enable debug output") do
-        $log.level = Logger::DEBUG
-      end
       opts.on("-v", "--verbose", "Enable verbose output") do
         $log.level = Logger::INFO
+      end
+      opts.on("-d", "--debug", "Enable debug output") do
+        $log.level = Logger::DEBUG
       end
       opts.on("-g [POSTID]", "--get [POSTID]", "Retrieve post as text") do |pid|
         attrs[:postid] = pid


### PR DESCRIPTION
When options --debug and --verbose are specified, use the log level
debug instead of verbose as it includes all messages of the other log
levels.

Noticed this when reading issue #53
