### PR TITLE
Enable Travis build notifications on IRC.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,6 @@ script:
   - bundle exec rake db:create
   - bundle exec rake db:migrate
   - bundle exec rake test
+
+notifications:
+  irc: "chat.freenode.net#graveio"


### PR DESCRIPTION
Enabling notifications regarding Travis builds to be sent to
IRC channel #graveio on Freenode would help propagating
changes.
