### PR TITLE
Fix attribute name in apikey migration

### DIFF
--- a/db/migrate/20140202010251_add_apikey_id_to_users.rb
+++ b/db/migrate/20140202010251_add_apikey_id_to_users.rb
@@ -3,7 +3,7 @@ class AddApikeyIdToUsers < ActiveRecord::Migration
     add_column :users, :apikey_id, :integer
 
     User.all.each do |user|
-      unless user.api_key.present?
+      unless user.apikey.present?
         user.add_new_api_key
       end
     end


### PR DESCRIPTION
Change attribute in migration from api_key to apikey
