### PR TITLE
Avoid "joined/left" messages on Travis Build Notification on IRC

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ notifications:
   irc:
     channels:
       - "chat.freenode.net#graveio"
-    on_success: change
+    on_success: always
     on_failure: always
     use_notice: true
     skip_join: true


### PR DESCRIPTION
Avoid the noisy "joined/left" messages on Travis Build Notification on IRC
and always propagate build result. We can adapt the Notification settings
to our needs later on.
