### PR TITLE
Better position for error and notice message

### DIFF
--- a/app/assets/stylesheets/common.css.scss
+++ b/app/assets/stylesheets/common.css.scss
@@ -1,0 +1,4 @@
+#alert_notice {
+  text-align: right;
+  padding-right: 20px;
+}

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -38,4 +38,8 @@
         <% end %>
     </div>
   </div>
+  <div id='alert_notice'>
+     <p id="notice"><%= notice %></p>
+     <p id="alert"><%= alert %></p>
+  </div>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,8 +12,6 @@
 <body>
    <%= render :partial => 'layouts/navbar' %>
    <div class="container">
-     <p id="notice"><%= notice %></p>
-     <p id="alert"><%= alert %></p>
      <%= yield %>
      <div class="center">
        <%=image_tag "loading.gif", :class => 'loading none'%>


### PR DESCRIPTION
- since we included the error and notice message in the container of the
  page you were not able to see some of the error/notice messages, if
  you scrolled down too far.
