### PR TITLE
Get rid of deprecation warning in def like_json().

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -150,8 +150,8 @@ class PostsController < ApplicationController
   end
 
   def like_json(post)
-   likes = post.likedislikes.find_all_by_liked(true)
-   dislikes = post.likedislikes.find_all_by_liked(false)
+   likes = post.likedislikes.where(:liked => true)
+   dislikes = post.likedislikes.where(:liked => false)
    liker = likes.collect { |l| User.find(l.liker).email }.join(", ")
    disliker = dislikes.collect { |l| User.find(l.liker).email }.join(", ")
    return { 


### PR DESCRIPTION
While getting aquainted to the code in PostController
i've noticed that the queries in like_json() are considered
obsolete. This diff fixes the warning.
