### PR TITLE
Make post title clickable

### DIFF
--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -1,7 +1,7 @@
 <% @post = post %>
 <div class="preview_area">
 <% if @post.title.present? %>
-  <legend><%= @post.title %></legend>
+  <legend><%= link_to @post.title, post_path(@post) %></legend>
 <% else %>
   <span>&nbsp;</span>
 <% end %>


### PR DESCRIPTION
Make the post title a link to the post's page.
So you don't have to find the tiny options button to get the
full post.
