### PR TITLE
Use relative links to repo content in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 graveio provides an easy-to-use and install Pastebin-Solution
 intended for inhouse Use.
 
-![Screenshot](https://raw.github.com/kmerz/graveio/master/screenshot.png)
+![Screenshot](screenshot.png)
 
 Installing:
 -  clone this repository
@@ -48,7 +48,7 @@ Ubuntu 12.04. providing ruby 1.9.3 via rvm(1), the latest nodejs stable
 release and sqlite3 as database.
 The IP address assigned to the host is 192.168.10.10 which can be changed
 by adapting the parameter "config.vm.network" in
-[Vagrantfile](https://github.com/kmerz/graveio/blob/master/Vagrantfile)
+[Vagrantfile](Vagrantfile)
 accordingly.
 The setup takes a couple of minutes. After the installation has finished
 you can login to the machine by running: `vagrant ssh`


### PR DESCRIPTION
As github suggests in it's markdown tutorial, you should use
relative links to point to content of your repo.
So it is easier for people to fork and still have a correct
Readme.
