### PR TITLE
The changes were made to be able to render text as markdown

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem 'rails', '~>4.0.1'
 # gem 'rails', :git => 'git://github.com/rails/rails.git'
 
 gem 'sqlite3'
-
+gem 'redcarpet'
 gem 'sass-rails'
 gem 'railties'
 gem 'coffee-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,6 +96,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rake (10.1.0)
+    redcarpet (3.3.4)
     sass (3.2.9)
     sass-rails (4.0.0)
       railties (>= 4.0.0.beta, < 5.0)
@@ -143,7 +144,11 @@ DEPENDENCIES
   pygments.rb!
   rails (~> 4.0.1)
   railties
+  redcarpet
   sass-rails
   sqlite3
   thin
   uglifier
+
+BUNDLED WITH
+   1.12.3

--- a/app/assets/stylesheets/posts.css.scss
+++ b/app/assets/stylesheets/posts.css.scss
@@ -81,6 +81,11 @@
 .diff li.diff-comment { display: none; }
 .diff li.diff-block-info { background: none repeat scroll 0 0 gray; }
 
+.markdown {
+  border-bottom: 1px solid darkgrey;
+  padding-bottom: 20px;
+}
+
 pre.line-pre {
   margin: 0;
   padding: 0;

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -238,6 +238,13 @@ class PostsController < ApplicationController
     end
   end
 
+  def markdown
+    @post = Post.find(params[:id])
+    respond_to do |format|
+      format.html {render :markdown}
+    end
+  end
+
   private
 
   def post_params

--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -1,5 +1,26 @@
 module PostsHelper
 
+  def markdown(post)
+    options = {
+      filter_html:     true,
+      hard_wrap:       true,
+      link_attributes: { rel: 'nofollow', target: "_blank" },
+      space_after_headers: true,
+      fenced_code_blocks: true
+    }
+
+    extensions = {
+      autolink:           true,
+      superscript:        true,
+      disable_indented_code_blocks: true
+    }
+
+    renderer = Redcarpet::Render::HTML.new(options)
+    markdown = Redcarpet::Markdown.new(renderer, extensions)
+
+    markdown.render(post.content).html_safe
+  end
+
   def preview_content(post)
     options = { options: {encoding: 'utf-8'} }
     if Pygments::Lexer.find(post.content_type)

--- a/app/views/posts/_options.html.erb
+++ b/app/views/posts/_options.html.erb
@@ -30,6 +30,12 @@
       <i class="icon-download"></i>
     <% end %>
 
+    <%= link_to markdown_post_path(@post), :class => "btn btn-mini",
+      :title => "Markdown" do %>
+      <i class="icon-flag"></i>
+    <% end %>
+
+
     <% unless current_page?(root_url) || current_page?(posts_path) %>
       <%= link_to posts_path, :class => "btn btn-mini", :title => "Posts" do %>
         <i class="icon-align-justify"></i>

--- a/app/views/posts/markdown.html.erb
+++ b/app/views/posts/markdown.html.erb
@@ -1,0 +1,18 @@
+<div class="row">
+  <div class="markdown">
+     <%= markdown(@post) %>
+  </div>
+
+  <% if @post.author.present? %>
+    <p class="author">- <%= @post.author %></p>
+  <% end %>
+
+  <%= render 'options' %>
+
+  <input id="post_url" class="input-xlarge uneditable-input" type="text"
+    value="<%= post_url(@post) %>"></input>
+
+  <br/><br/>
+  <%= render 'like_dislike' %>
+  <%= render 'comments/comment' %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Fox::Application.routes.draw do
       get :diff
       get :like
       get :dislike
+      get :markdown
     end
   end
   resources :posts, :as => :p

--- a/test/functional/posts_controller_test.rb
+++ b/test/functional/posts_controller_test.rb
@@ -157,6 +157,13 @@ class PostsControllerTest < ActionController::TestCase
     assert_template(:diff)
   end
 
+  test "should show markdown for post" do
+    get :markdown, :id => 106
+    assert_response :success
+    assert_not_nil(:post)
+    assert_template(:markdown)
+  end
+
   test "should upload file from form" do
     test_image = "test/fixtures/test.txt"
     file = Rack::Test::UploadedFile.new(test_image, "text/plain")


### PR DESCRIPTION
- Gem 'redcarpet' (markdown to html parser) has been added
- route :markdown has been added
- 'markdown' method has been added to the posts_controller
- 'markdown' method that uses the redcarpet gem has been added to the posts_helper
- markdown.html.erb has been added
- a button that calls for the markdown view has been added to the gui
- posts.css.scss got modified for a cleaner look of the markdown view
- one test has been added to post_controller_tests that tries to access a /markdown route